### PR TITLE
Add table builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ On top of this, you can also change the HTML files in `frontend/views` or the ma
 # Adding grammar/vocab lists
 All lists are defined in the `lists` collection within the `grammarer-db` database. If this doesn't exist (it isn't created by default), you will need to add it manually. It's easiest to do this through [Mongo Compass](https://www.mongodb.com/products/compass), a desktop MongoDB client. You will also need the MongoDB CLI to insert large JSON objects in their original format.
 
+**Grammar lists can now be added through a simple and friendly GUI by an admin user. Simply sign in and click Magic Dashboard > Create and manage grammar/vocab lists > Add grammar list. This feature is yet to be implemented for vocab lists.**
+
 Grammar and vocab lists have slightly different structures so they are explained separately.
 
 ### Grammar

--- a/controller.js
+++ b/controller.js
@@ -519,6 +519,34 @@ MongoClient.connect(MongoString, function(err,client){
         }
     });
 
+    app.get("/d/adminlists", (req,res)=>{
+        if(req.session.authed&&req.session.authrole==="admin"){
+            dbo.collection("lists").find({}).toArray((err,data)=>{
+                if(err) throw err;
+                res.json(data);
+            });
+        }else{
+            res.send("Not authorised");
+        }
+    });
+
+    app.get("/d/admindellist", (req,res)=>{
+        if(req.session.authed&&req.session.authrole==="admin"){
+            dbo.collection("lists").deleteOne({identifier:req.query.listid},(err)=>{
+                if(err) throw err;
+                res.json({
+                    success: true,
+                    error: null
+                });
+            });
+        }else{
+            res.json({
+                success: false,
+                error: "Not signed in or is not admin"
+            });
+        }
+    });
+
     app.get("/i/addlist", (req,res) => {
         if(req.session.authed&&req.session.authrole==="admin"){
             dbo.collection("lists").insertOne(JSON.parse(req.query.json), (err, response) => {

--- a/controller.js
+++ b/controller.js
@@ -547,14 +547,32 @@ MongoClient.connect(MongoString, function(err,client){
         }
     });
 
-    app.get("/i/addlist", (req,res) => {
+    app.get("/d/adminaddlist", (req,res) => {
         if(req.session.authed&&req.session.authrole==="admin"){
-            dbo.collection("lists").insertOne(JSON.parse(req.query.json), (err, response) => {
+            let json = JSON.parse(req.query.json);
+            dbo.collection("lists").findOne({identifier: json.identifier}, (err, list)=>{
                 if(err) throw err;
-                res.send(response);
+                if(list==null){
+                    dbo.collection("lists").insertOne(JSON.parse(req.query.json), (err, response) => {
+                        if(err) throw err;
+                        res.json({
+                            success: true,
+                            response: response,
+                            error: null
+                        });
+                    });
+                }else{
+                    res.json({
+                        success: false,
+                        error: "List with identifier '"+json.identifier+"' already exists"
+                    });
+                }
             });
         }else{
-            res.send("Not authorised");
+            res.json({
+                success: false,
+                error: "Not signed in or is not admin"
+            });
         }
     });
 

--- a/frontend/grammarer.js
+++ b/frontend/grammarer.js
@@ -784,19 +784,31 @@ g.controller("g-admin-lists", function($scope,$http,$location,$route,$rootScope)
         show:false,
         type:"grammar",
         table:{
-            head:["My", "first", "table", "example"],
+            head:[{name: "", editing: false},{name: "", editing: false},{name: "", editing: false},{name: "", editing: false}],
             rows:[
                 {
-                    first: "Example",
-                    cells:["My", "first", "table"]
+                    first: {name: "", editing: false},
+                    cells:[
+                        {name: "", editing: false},
+                        {name: "", editing: false},
+                        {name: "", editing: false}
+                    ]
                 },
                 {
-                    first: "Example",
-                    cells:["My", "first", "table"]
+                    first: {name: "", editing: false},
+                    cells:[
+                        {name: "", editing: false},
+                        {name: "", editing: false},
+                        {name: "", editing: false}
+                    ]
                 },
                 {
-                    first: "Example",
-                    cells:["My", "first", "table"]
+                    first: {name: "", editing: false},
+                    cells:[
+                        {name: "", editing: false},
+                        {name: "", editing: false},
+                        {name: "", editing: false}
+                    ]
                 }
             ]
         }
@@ -826,46 +838,103 @@ g.controller("g-admin-lists", function($scope,$http,$location,$route,$rootScope)
         $scope.modal.show = true;
     };
     $scope.listDblclick = function(e){
-        if(document.body.classList.contains("g-table-selected")){
-            let element = document.getElementsByClassName("g-selected-container")[0];
-            element.innerHTML = element.childNodes[0].value;
-            element.classList.remove("g-selected-container");
-            document.body.classList.remove("g-table-selected");
+        // If currently editing
+        if(document.body.classList.contains("g-table-editing")){
+            // Search and remove
+            // Head
+            for(let i in $scope.modal.table.head){
+                $scope.modal.table.head[i].editing = false;
+            }
+            for(let i in $scope.modal.table.rows){
+                // Body firsts
+                $scope.modal.table.rows[i].first.editing = false;
+                // Body cells
+                for(let x in $scope.modal.table.rows[i].cells){
+                    $scope.modal.table.rows[i].cells[x].editing = false;
+                }
+            }
+            document.body.classList.remove("g-table-editing");
         }
 
+        // Identify element
         let element = e.currentTarget;
-        let elementContent = element.innerHTML;
 
-        element.innerHTML = `<input type="text" value="${elementContent}" class="g-selected">`;
-        element.classList.add("g-selected-container");
-        document.body.classList.add("g-table-selected");
+        // Set element identifier from JSON object
+        let reference = $scope.modal.table;
+        if(element.parentNode.classList.contains("g-head")){
+            // Header object
+            reference = reference.head[element.cellIndex];
+        }else if(element.classList.contains("g-first")){
+            // First in body row
+            reference = reference.rows[element.parentNode.rowIndex - 1].first;
+        }else if(element.classList.contains("g-content")){
+            // Regular content
+            reference = reference.rows[element.parentNode.rowIndex - 1].cells[element.cellIndex - 1];
+        }
 
-        let input = element.childNodes[0];
-        input.select();
+        // Set reference to editing
+        reference.editing = true;
+        // Add class to body
+        document.body.classList.add("g-table-editing");
+    };
 
-        $(input).keypress(function(k){
-            if(k.which === 13) {
-                element.innerHTML = input.value;
-                $scope.modal.table.rows[element.parentNode.rowIndex - 1].cells[element.cellIndex - 1] = element.innerHTML;
-                element.classList.remove("g-selected-container");
-                document.body.classList.remove("g-table-selected");
-            }
-        });
-    }
+    $scope.listEnter = function(e, cell){
+        // If enter key pressed
+        if(e.keyCode === 13){
+            // Turn off editing for that cell
+            cell.editing = false;
+            // Remove class from body
+            document.body.classList.remove("g-table-editing");
+        }
+    };
 
     $scope.addC = function(){
-        let random = Math.floor(Math.random()*1000).toString()
-        $scope.modal.table.head.push(random);
+        $scope.modal.table.head.push({
+            name: " ",
+            editing: false
+        });
         let table = $scope.modal.table.rows;
         for(let i in table){
-            table[i].cells.push(random);
+            table[i].cells.push({
+                name: " ",
+                editing: false
+            });
         }
         $scope.modal.table.rows = table;
     };
+
     $scope.addR = function(){
+        let cells = [];
+        for(let i = 0; i < $scope.modal.table.rows[$scope.modal.table.rows.length - 1].cells.length; i++){
+            cells.push({
+                name: " ",
+                editing: false
+            });
+        }
         $scope.modal.table.rows.push({
-            first: "new",
-            cells: $scope.modal.table.rows[$scope.modal.table.rows.length - 1].cells
+            first: {name: "", editing: false},
+            cells: cells
         });
     };
+
+    $scope.delC = function($event){
+        $event.stopPropagation();
+
+        let element = $event.currentTarget.parentNode.parentNode;
+        let cellIndex = element.cellIndex;
+        $scope.modal.table.head.splice(cellIndex, 1);
+
+        for(let i in $scope.modal.table.rows){
+            $scope.modal.table.rows[i].cells.splice(cellIndex - 1, 1);
+        }
+    };
+
+    $scope.delR = function($event){
+        //$event.stopPropagation();
+
+        let element = $event.currentTarget.parentNode.parentNode.parentNode;
+        let rowIndex = element.rowIndex - 1;
+
+        $scope.modal.table.rows.splice(rowIndex, 1);
+    }
 });

--- a/frontend/table.css
+++ b/frontend/table.css
@@ -43,3 +43,18 @@
 #table .g-content{
     font-size: 1.75rem;
 }
+#table .g-selected-container{
+    padding: 0;
+    height: 100%;
+    position: relative;
+}
+#table .g-selected{
+    width: 100%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border: none;
+    padding: 15px;
+    font-size: 1.75rem;
+    background-color: lightblue;
+}

--- a/frontend/table.css
+++ b/frontend/table.css
@@ -58,3 +58,9 @@
     font-size: 1.75rem;
     background-color: lightblue;
 }
+#table.g-table-editor td, #table.g-table-editor th{
+    min-width: 75px;
+}
+#table .g-row-filler{
+    min-height: 20px;
+}

--- a/frontend/views/admin.html
+++ b/frontend/views/admin.html
@@ -10,6 +10,8 @@
 
 <p>This page enables admins and teachers to manage codes, cohorts and more. Please see <a href="https://github.com/palkerecsenyi/grammarer#user-control" target="_blank">the User Control documentation</a> for more information.</p>
 
+<p>To create and manage grammar/vocab lists, <a href="#!/admin/lists">click here.</a></p>
+
 <hr/>
 
 <div class="columns">

--- a/frontend/views/home.html
+++ b/frontend/views/home.html
@@ -34,7 +34,20 @@
         <p class="subtitle has-text-grey has-text-centered" style="margin-top: 10px;">{{orgInfo.name}}</p>
     </div>
     <p class="has-text-grey has-text-centered">For optimal functionality, don't use Edge or IE.<br>Grammarer works best in Chrome.</p>
-    <div style="position: fixed; bottom: 0; right: 0; left: 0; padding: 10px 0; background: white;">
-        <p class="has-text-grey" style="text-align: center;">Copyright © 2018 Pal Kerecsenyi.</p>
+    <div style="position: fixed; bottom: 0; right: 0; left: 0; padding: 10px 0; background: white; z-index: 4;" class="has-text-grey has-text-centered">
+        <p>
+            <a href="https://github.com/palkerecsenyi/grammarer" target="_blank">
+                Grammarer
+            </a> |
+            Latest version
+            <a href="{{gmRelease.html_url}}" target="_blank">
+                {{gmRelease.tag_name}}
+            </a> |
+            This version
+            <a href="https://github.com/palkerecsenyi/grammarer/releases/tag/v{{config.gmVersion}}" target="_blank">
+                v{{config.gmVersion}}
+            </a>
+        </p>
+        <p>Copyright © 2018 Pal Kerecsenyi.</p>
     </div>
 </div>

--- a/frontend/views/listadmin.html
+++ b/frontend/views/listadmin.html
@@ -52,14 +52,14 @@
                 <table id="table">
                     <thead>
                         <tr class="g-row g-fixed">
-                            <th ng-repeat="column in modal.table.head track by $index" ng-dblclick="listDblclick($event)">{{column}}</th>
+                            <th ng-repeat="column in modal.table.head" ng-dblclick="listDblclick($event)">{{column}}</th>
                             <th><button class="button is-primary" ng-click="addC()">+ Column</button></th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr ng-repeat="row in modal.table.rows track by $index" class="g-row g-fluid">
                             <th class="g-cell" ng-dblclick="listDblclick($event)">{{row.first}}</th>
-                            <td ng-repeat="cell in row.cells track by $index" class="g-content g-cell" ng-dblclick="listDblclick($event)">{{cell}}</td>
+                            <td ng-repeat="cell in row.cells" class="g-content g-cell" ng-dblclick="listDblclick($event)">{{cell}}</td>
                         </tr>
                         <tr>
                             <td><button class="button is-primary" ng-click="addR()">+ Row</button></td>

--- a/frontend/views/listadmin.html
+++ b/frontend/views/listadmin.html
@@ -48,20 +48,42 @@
             <button class="delete" aria-label="close" ng-click="modal.show = false"></button>
         </header>
         <section class="modal-card-body">
+
             <div class="g-table-container">
-                <table id="table">
-                    <thead>
-                        <tr class="g-row g-fixed">
-                            <th ng-repeat="column in modal.table.head" ng-dblclick="listDblclick($event)">{{column}}</th>
-                            <th><button class="button is-primary" ng-click="addC()">+ Column</button></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr ng-repeat="row in modal.table.rows track by $index" class="g-row g-fluid">
-                            <th class="g-cell" ng-dblclick="listDblclick($event)">{{row.first}}</th>
-                            <td ng-repeat="cell in row.cells" class="g-content g-cell" ng-dblclick="listDblclick($event)">{{cell}}</td>
-                        </tr>
-                        <tr>
+                <table id="table" class="g-table-editor">
+                            <thead>
+                            <tr class="g-row g-head g-fixed">
+                                <th ng-repeat="column in modal.table.head track by $index" ng-click="listDblclick($event)" ng-class="{'g-selected-container':column.editing}" class="g-cell">
+                                    <div ng-if="!column.editing">{{column.name}}</div>
+                                    <div ng-if="column.editing">
+                                        <input type="text" ng-model="column.name" class="g-selected" ng-keypress="listEnter($event, column)">
+                                    </div>
+                                    <div ng-if="$index!==0">
+                                        <a href ng-click="delC($event)">Delete</a>
+                                    </div>
+                                </th>
+                                <th><button class="button is-primary" ng-click="addC()">+ Column</button></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr ng-repeat="row in modal.table.rows track by $index" class="g-row g-fluid">
+                                <th class="g-cell g-first" ng-click="listDblclick($event)" ng-class="{'g-selected-container':row.first.editing}">
+                                    <div ng-if="!row.first.editing" class="g-row-filler">{{row.first.name}}</div>
+                                    <div ng-if="row.first.editing" class="g-row-filler">
+                                        <input type="text" ng-model="row.first.name" class="g-selected" ng-keypress="listEnter($event, row.first)">
+                                    </div>
+                                    <div>
+                                        <a href ng-click="delR($event)">Delete</a>
+                                    </div>
+                                </th>
+                                <td ng-repeat="cell in row.cells track by $index" class="g-content g-cell" ng-click="listDblclick($event)" ng-class="{'g-selected-container':cell.editing}">
+                                    <div ng-if="!cell.editing" class="g-row-filler">{{cell.name}}</div>
+                                    <div ng-if="cell.editing" class="g-row-filler">
+                                        <input type="text" ng-model="cell.name" class="g-selected" ng-keypress="listEnter($event, cell)">
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
                             <td><button class="button is-primary" ng-click="addR()">+ Row</button></td>
                         </tr>
                     </tbody>

--- a/frontend/views/listadmin.html
+++ b/frontend/views/listadmin.html
@@ -1,0 +1,76 @@
+<nav class="breadcrumb">
+    <ul>
+        <li><a href="#!/">Home</a></li>
+        <li><a href="#!/lists">Lists</a></li>
+        <li><a href="#!/admin">Magic Dashboard</a></li>
+        <li class="is-active"><a href="#!/admin/tables">List manager</a></li>
+    </ul>
+</nav>
+
+<p class="title is-3 tk-rigid-square">List manager</p>
+<p>This page enables admins and teachers to manage lists and create them using the Grammarer Table Builder.</p>
+
+<hr/>
+
+<button class="button is-medium is-primary" style="margin-bottom:10px;" ng-click="listInsert()">Add new!</button>
+
+<div class="g-table-container">
+    <table class="table" style="width: 100%;">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Language</th>
+                <th>Name</th>
+                <th>Type</th>
+
+                <th>Delete</th>
+                <th>Edit</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr ng-repeat="list in lists">
+                <td><code>{{list.identifier}}</code></td>
+                <td>{{list.language}}</td>
+                <td><strong>{{list.title || "Checklist "+list.number}}</strong></td>
+                <td>{{list.type}}</td>
+                <td><button class="button is-danger" ng-click="listDelete($event, list.identifier)">Delete</button></td>
+                <td><button class="button is-primary" ng-click="listEdit($event, list.identifier)">Edit</button></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="modal" ng-class="{'is-active': modal.show}">
+    <div class="modal-background" ng-click="modal.show = false"></div>
+    <div class="modal-card" style="width: unset;">
+        <header class="modal-card-head">
+            <p class="modal-card-title">Add new grammar list</p>
+            <button class="delete" aria-label="close" ng-click="modal.show = false"></button>
+        </header>
+        <section class="modal-card-body">
+            <div class="g-table-container">
+                <table id="table">
+                    <thead>
+                        <tr class="g-row g-fixed">
+                            <th ng-repeat="column in modal.table.head track by $index" ng-dblclick="listDblclick($event)">{{column}}</th>
+                            <th><button class="button is-primary" ng-click="addC()">+ Column</button></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr ng-repeat="row in modal.table.rows track by $index" class="g-row g-fluid">
+                            <th class="g-cell" ng-dblclick="listDblclick($event)">{{row.first}}</th>
+                            <td ng-repeat="cell in row.cells track by $index" class="g-content g-cell" ng-dblclick="listDblclick($event)">{{cell}}</td>
+                        </tr>
+                        <tr>
+                            <td><button class="button is-primary" ng-click="addR()">+ Row</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        <footer class="modal-card-foot">
+            <button class="button is-success" ng-click="listSave()">Save changes</button>
+            <button class="button" ng-click="modal.show = false">Cancel</button>
+        </footer>
+    </div>
+</div>

--- a/frontend/views/listadmin.html
+++ b/frontend/views/listadmin.html
@@ -12,7 +12,7 @@
 
 <hr/>
 
-<button class="button is-medium is-primary" style="margin-bottom:10px;" ng-click="listInsert()">Add new!</button>
+<button class="button is-medium is-primary" style="margin-bottom:10px;" ng-click="listInsert()">Add grammar list</button>
 
 <div class="g-table-container">
     <table class="table" style="width: 100%;">
@@ -24,7 +24,7 @@
                 <th>Type</th>
 
                 <th>Delete</th>
-                <th>Edit</th>
+                <!--<th>Edit</th>-->
             </tr>
         </thead>
         <tbody>
@@ -34,7 +34,7 @@
                 <td><strong>{{list.title || "Checklist "+list.number}}</strong></td>
                 <td>{{list.type}}</td>
                 <td><button class="button is-danger" ng-click="listDelete($event, list.identifier)">Delete</button></td>
-                <td><button class="button is-primary" ng-click="listEdit($event, list.identifier)">Edit</button></td>
+                <!--<td><button class="button is-primary" ng-click="listEdit($event, list.identifier)">Edit</button></td>-->
             </tr>
         </tbody>
     </table>
@@ -49,7 +49,7 @@
         </header>
         <section class="modal-card-body">
 
-            <div class="g-table-container">
+            <div class="g-table-container" ng-if="modal.slide === 1">
                 <table id="table" class="g-table-editor">
                             <thead>
                             <tr class="g-row g-head g-fixed">
@@ -62,7 +62,9 @@
                                         <a href ng-click="delC($event)">Delete</a>
                                     </div>
                                 </th>
-                                <th><button class="button is-primary" ng-click="addC()">+ Column</button></th>
+                                <th>
+                                    <button class="button is-primary" ng-click="addC($event)">+ Column</button>
+                                </th>
                             </tr>
                             </thead>
                             <tbody>
@@ -89,10 +91,60 @@
                     </tbody>
                 </table>
             </div>
+
+            <div ng-if="modal.slide === 2">
+                <p class="subtitle is-4">Information</p>
+
+                <label for="g-i-name">Give your list a descriptive name</label>
+                <input id="g-i-name" ng-model="modal.setup.name" class="input" style="margin-bottom: 15px;">
+
+                <label for="g-i-language">Select the language it belongs to</label>
+                <br/>
+                <div class="select" style="width:100%; margin-bottom: 15px;">
+                    <select id="g-i-language" ng-model="modal.setup.language" style="width:100%;">
+                        <option ng-repeat="lang in config.languages">{{lang}}</option>
+                    </select>
+                </div>
+
+                <label for="g-i-id">Give it a machine-readable (not shown to users) identifier code</label>
+                <input id="g-i-id" ng-model="modal.setup.identifier" class="input" style="margin-bottom: 15px;">
+
+                <label for="g-i-dir">What direction should the list go in?</label>
+                <br/>
+                <div class="select" style="margin-bottom: 15px;">
+                    <select id="g-i-dir" ng-model="modal.setup.direction">
+                        <option value="left">Left</option>
+                        <option value="down" selected>Down</option>
+                    </select>
+                </div>
+
+                <hr/>
+
+                <p class="subtitle is-4">Preview</p>
+                <div class="columns">
+                    <div class="column is-one-third">
+                        <div class="card">
+                            <header class="card-header">
+                                <p class="card-header-title">{{ modal.setup.language[0].toUpperCase() + modal.setup.language.substring(1) }} | {{ modal.setup.name }}</p>
+                            </header>
+                            <div class="card-content">
+                                <div class="content">
+                                    <p>Average score: 50%</p>
+                                </div>
+                            </div>
+                            <footer class="card-footer">
+                                <a href class="card-footer-item">Study!</a>
+                            </footer>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </section>
         <footer class="modal-card-foot">
-            <button class="button is-success" ng-click="listSave()">Save changes</button>
-            <button class="button" ng-click="modal.show = false">Cancel</button>
+            <button class="button is-success" ng-click="modal.slide = 2" ng-if="modal.slide === 1">Continue</button>
+            <button class="button is-success" ng-click="listSave($event)" ng-if="modal.slide === 2">Complete</button>
+            <button class="button" ng-click="modal.slide = 1" ng-if="modal.slide === 2">Back</button>
+            <button class="button is-warning" ng-click="modal.show = false">Close</button>
         </footer>
     </div>
 </div>

--- a/gm-options.json
+++ b/gm-options.json
@@ -18,7 +18,11 @@
     "printables"
   ],
   "languages": [
-    "german"
+    "french",
+    "spanish",
+    "german",
+    "greek",
+    "latin"
   ],
   "printables": [
     {

--- a/gm-options.json
+++ b/gm-options.json
@@ -31,5 +31,6 @@
       "name": "Definite Article",
       "fileName": "y9_gratin_greek_defart.pdf"
     }
-  ]
+  ],
+  "gmVersion": "0.1.0"
 }

--- a/setup.js
+++ b/setup.js
@@ -41,6 +41,7 @@ fs.readFile("gm-options.json", function(err, config){
             packageJson.scripts.start = `${command} PORT=${json.ports.production}&&${command} DBSTRING=${json.dbString}&&node controller.js`;
             packageJson.scripts["start-dev"] = `${command} PORT=${json.ports.development}&&${command} DBSTRING=${json.dbString}&&node controller.js`;
             packageJson.scripts["dev-reset-db"] = `${command} DBSTRING=${json.dbString}&&node reset.js`;
+            packageJson.version = json.gmVersion;
 
             gmConsole("Writing package.json", "\x1b[33m");
             fs.writeFileSync("package.json", JSON.stringify(packageJson, null, 2));


### PR DESCRIPTION
This PR adds a table building GUI for constructing grammar lists without having to interact with JSON objects. The feature has been fully tested. It requires a re-run of the `node setup` command as some setup features have also changed.

![Demo image](https://image.ibb.co/fW3ZDJ/image.png)

The feature is yet to be implemented for vocab lists, despite their relative simplicity. For now, they must be added as explained in `README.md` (with JSON objects).